### PR TITLE
Add .gitattributes to force `LF` for .sh file line endings - fix devcontainer deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Git will always convert line endings to LF on checkout. 
+# Used for files that must keep LF endings, even on Windows.
+*.sh text eol=lf


### PR DESCRIPTION
## Purpose

Closes #9 
Depending on OS you use and your Git settings, the `.sh` shell script files for Linux are cloned and given `CR LF` (Windows) line endings. This caused script execution to fail with error such as `syntax error near unexpected token `$'\r''` which resulted in the library db failing to deploy and sql tools failing to install. 

> [318402 ms] Start: Run in container: /bin/sh -c bash .devcontainer/sql/postCreateCommand.sh P@ssw0rd! './bin/Debug/' './.devcontainer/sql/'
> .devcontainer/sql/postCreateCommand.sh: line 7: $'\r': command not found
> 0+1 records in
> 0+1 records out
> 28 bytes copied, 0.000887324 s, 31.6 kB/s
> .devcontainer/sql/postCreateCommand.sh: line 9: syntax error near unexpected token `$'\r''
> 'devcontainer/sql/postCreateCommand.sh: line 9: `for i in {1..60};
> 
> What's next:
>     Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug cdd17efc8eb2df6013b3229488477cd30bf0d5baed79c624fbdf1684e7c62768
>     Learn more at https://docs.docker.com/go/debug-cli/
> [319057 ms] postCreateCommand failed with exit code 2. Skipping any further user-provided commands.
> Done. Press any key to close the terminal.

Before (installSqlTools.sh):
![image](https://github.com/Azure-Samples/azure-sql-library-app-blazor/assets/6414189/7883b401-21f7-4990-9acb-1adbb1f44cba)

After (installSqlTools.sh):
![image](https://github.com/Azure-Samples/azure-sql-library-app-blazor/assets/6414189/27a352dd-8ccc-4ffa-93d2-00a8e67260cd)


## Does this introduce a breaking change?
Unclear, to get this working, devs will need to reclone the repo.
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Clone the repo once this is in master (tested in a fork), and then see that .sh files no longer have CR LF line endings. And only have LF.
